### PR TITLE
Hide suggestion list dividers on hover

### DIFF
--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -249,11 +249,20 @@ const Suggestion = styled('li')`
   grid-template-columns: 170px auto;
   align-items: center;
   padding: ${space(1)} 0;
-  border-bottom: 1px solid ${p => p.theme.innerBorder};
+  border-top: 1px solid ${p => p.theme.innerBorder};
   gap: ${space(1)};
+
+  &:first-child {
+    border-top: none;
+  }
 
   &:hover {
     cursor: pointer;
+    border-top-color: transparent;
+  }
+
+  &:hover + & {
+    border-top-color: transparent;
   }
 
   &:hover .data-actions-wrapper {


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR improves the user experience of search suggestion lists by making the dividers between items disappear when a user hovers over an item.

Previously, the persistent dividers could be visually distracting. To create a seamless effect without layout shifts, the `border-bottom` was replaced with `border-top` for the dividers. On hover, the `border-top` of the hovered item and its immediate sibling is set to transparent, providing a cleaner visual experience. The first item's top border is also removed for consistency.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4c7a6c0-04d5-49f4-957a-95cc4c0b622b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4c7a6c0-04d5-49f4-957a-95cc4c0b622b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

